### PR TITLE
[FEATURE] Allow post creation command execution to fail

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "mteu/php-template",
-	"description": "Basic PHP template",
+	"description": "Simple PHP template",
 	"license": "GPL-3.0-or-later",
 	"type": "project-builder-template",
 	"authors": [
@@ -12,12 +12,12 @@
 		}
 	],
 	"require": {
-		"cpsit/project-builder": "^2.6"
+		"cpsit/project-builder": "^2.7"
 	},
 	"require-dev": {
 		"armin/editorconfig-cli": "^2.0",
-		"ergebnis/composer-normalize": "^2.39",
-		"friendsoftwig/twigcs": "^6.2"
+		"ergebnis/composer-normalize": "^2.42",
+		"friendsoftwig/twigcs": "^6.4"
 	},
 	"config": {
 		"allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "51a1544d0f58346791c61b40f047375a",
+    "content-hash": "660d073277e8e7adf88454b808d96cf4",
     "packages": [
         {
             "name": "cocur/slugify",
@@ -3877,16 +3877,16 @@
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.28.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "ecaafce9f77234a6a449d29e49267ba10499116d"
+                "reference": "a287ed7475f85bf6f61890146edbc932c0fff919"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/ecaafce9f77234a6a449d29e49267ba10499116d",
-                "reference": "ecaafce9f77234a6a449d29e49267ba10499116d",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/a287ed7475f85bf6f61890146edbc932c0fff919",
+                "reference": "a287ed7475f85bf6f61890146edbc932c0fff919",
                 "shasum": ""
             },
             "require": {
@@ -3899,9 +3899,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -3944,7 +3941,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.29.0"
             },
             "funding": [
                 {
@@ -3960,20 +3957,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-26T09:30:37+00:00"
+            "time": "2024-01-29T20:11:03+00:00"
         },
         {
             "name": "symfony/polyfill-php72",
-            "version": "v1.28.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php72.git",
-                "reference": "70f4aebd92afca2f865444d30a4d2151c13c3179"
+                "reference": "861391a8da9a04cbad2d232ddd9e4893220d6e25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/70f4aebd92afca2f865444d30a4d2151c13c3179",
-                "reference": "70f4aebd92afca2f865444d30a4d2151c13c3179",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/861391a8da9a04cbad2d232ddd9e4893220d6e25",
+                "reference": "861391a8da9a04cbad2d232ddd9e4893220d6e25",
                 "shasum": ""
             },
             "require": {
@@ -3981,9 +3978,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -4020,7 +4014,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php72/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-php72/tree/v1.29.0"
             },
             "funding": [
                 {
@@ -4036,7 +4030,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-26T09:26:14+00:00"
+            "time": "2024-01-29T20:11:03+00:00"
         }
     ],
     "aliases": [],

--- a/config.yaml
+++ b/config.yaml
@@ -31,9 +31,12 @@ steps:
     options:
       command: "composer update && composer normalize"
       skipConfirmation: true
+      allowFailure: true
   - type: runCommand
     options:
       command: "git init --initial-branch=main"
+      skipConfirmation: true
+      allowFailure: true
 
 properties:
   # Project


### PR DESCRIPTION
This template currently executes two shell commands at the end of project file generation. With https://github.com/CPS-IT/project-builder/releases/tag/2.7.0 it's now possible to proceed with the project building even if one of these command fails. This PR makes use of that new feature allowing to failing commands. Consequently, the template now requires `^2.7.0`.